### PR TITLE
Resize and position layer relative to artboard

### DIFF
--- a/Icon Stamper.sketchplugin
+++ b/Icon Stamper.sketchplugin
@@ -1,4 +1,7 @@
-var graphics = getSelection();
+var graphics = getSelection(),
+  sourceArtboardSize = 1024,
+  percentageX = graphics.frame().x() / sourceArtboardSize,
+  percentageY = graphics.frame().y() / sourceArtboardSize;
 
 if (graphics != null) {
   var groupName = graphics.name();
@@ -11,7 +14,7 @@ if (graphics != null) {
     var size = f.width();
     var offset = 2000;
 
-    if (size < 1024) {
+    if (size < sourceArtboardSize) {
 
       // This is a kluge.
       // If you paste layers in a artboard and those layers are larger than
@@ -28,8 +31,13 @@ if (graphics != null) {
       var newGroup = l.objectAtIndex(l.count() - 1);
 
       if (newGroup.name() == groupName + ' 2') {
-        newGroup.frame().width = size;
-        newGroup.frame().height = size;
+        var relativeSizeFactorWidth = newGroup.frame().width() / sourceArtboardSize,
+          relativeSizeFactorHeight = newGroup.frame().height() / sourceArtboardSize;
+
+        newGroup.frame().width = size * relativeSizeFactorWidth;
+        newGroup.frame().height = size * relativeSizeFactorHeight;
+        newGroup.frame().x = size * percentageX;
+        newGroup.frame().y = size * percentageY;
 
         newGroup.setName(groupName);
       }


### PR DESCRIPTION
What this does:
- Keeps the original name of the group, instead of adding ' 2'.
- Resizes the group relative to the destination artboard.
- Positions the group within and relative to the destination artboard.

I've tested with text within the group, which works as well.

As far as I can see, this closes #2 and #3.

![screenshot 2014-06-26 21 59 35](https://cloud.githubusercontent.com/assets/67565/3404039/ae8c323e-fd6c-11e3-99a9-9c703cb60c3a.png)
